### PR TITLE
Fixed module path in registration.php

### DIFF
--- a/registration.php
+++ b/registration.php
@@ -1,6 +1,7 @@
 <?php
 
 \Magento\Framework\Component\ComponentRegistrar::register(
-    \Magento\Framework\Component\ComponentRegistrar::MODULE, 'SamedayCourier_Shipping',
-    isset($file) ? dirname($file) : __DIR__
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'SamedayCourier_Shipping',
+    __DIR__
 );


### PR DESCRIPTION
This fixes the invalid template error in the backend order view page.
![2021-11-01 18 46 03](https://user-images.githubusercontent.com/6533394/139846079-198759e3-7667-4aaa-b3c8-5b45b4c097d7.png)


