### PR TITLE
Fix services bug

### DIFF
--- a/Model/Carrier/Shipping.php
+++ b/Model/Carrier/Shipping.php
@@ -101,7 +101,8 @@ class Shipping extends AbstractCarrier implements CarrierInterface
         foreach ($services as $service) {
             $isLockerService = in_array($service->getCode(), ServiceInterface::SERVICES_WITH_LOCKERS);
             $lockerMaxItems = $service->getLockerMaxItems();
-            if (sizeof($request->getAllItems()) > $lockerMaxItems && $isLockerService) {
+			$requestItems = $request->getAllItems();
+            if (sizeof($requestItems) > $lockerMaxItems && $isLockerService) {
                 continue;
             }
 

--- a/Model/Service.php
+++ b/Model/Service.php
@@ -70,6 +70,7 @@ class Service extends AbstractExtensibleModel
             ->setPrice($this->getData('price'))
             ->setIsPriceFree($this->getData('is_price_free'))
             ->setPriceFree($this->getData('price_free'))
+            ->setLockerMaxItems($this->getData('locker_max_items'))
             ->setStatus($this->getData('status'))
             ->setUseEstimatedCost($this->getData('use_estimated_cost'));
 

--- a/registration.php
+++ b/registration.php
@@ -1,6 +1,7 @@
 <?php
 
 \Magento\Framework\Component\ComponentRegistrar::register(
-    \Magento\Framework\Component\ComponentRegistrar::MODULE, 'SamedayCourier_Shipping',
-    isset($file) ? dirname($file) : __DIR__
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'SamedayCourier_Shipping',
+    __DIR__
 );


### PR DESCRIPTION
Module was not returning any services because $service->getLockerMaxItems() function was returning NULL. Closer inspection revealed the value was not being set in the public function getDataModel() function. This was fixed by adding it to the serviceDataFactory():


```
    /**
     * @return ServiceInterface
     */
    public function getDataModel()
    {
        $serviceDataObject = $this->serviceDataFactory->create()
            ->setId($this->getData('id'))
            ->setSamedayId($this->getData('sameday_id'))
            ->setSamedayName($this->getData('sameday_name'))
            ->setIsTesting($this->getData('is_testing'))
            ->setName($this->getData('name'))
            ->setCode($this->getData('code'))
            ->setPrice($this->getData('price'))
            ->setIsPriceFree($this->getData('is_price_free'))
            ->setPriceFree($this->getData('price_free'))
            ->setLockerMaxItems($this->getData('locker_max_items'))
            ->setStatus($this->getData('status'))
            ->setUseEstimatedCost($this->getData('use_estimated_cost'));

        return $serviceDataObject;
    }
```
