### PR TITLE
compatible order id with sales order entity_id

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,7 +1,7 @@
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="samedaycourier_shipping_awb" resource="default" engine="innodb" comment="Samedaycourier AWB list">
         <column xsi:type="int" identity="true" name="id" padding="11" unsigned="false" nullable="false" comment="AWB Local ID"/>
-        <column xsi:type="int" name="order_id" padding="11" unsigned="false" nullable="false" comment="Magento order ID"/>
+        <column xsi:type="int" name="order_id" padding="11" unsigned="true" nullable="false" comment="Magento order ID"/>
         <column xsi:type="varchar" name="awb_number" length="255" nullable="false" comment="AWB Number"/>
         <column xsi:type="text" name="parcels" nullable="false" comment="AWB Parcels"/>
         <column xsi:type="decimal" name="awb_cost" scale="2" nullable="false" comment="AWB Cost"/>


### PR DESCRIPTION
Fixes error
```
SQLSTATE[HY000]: General error: 3780 Referencing column 'order_id' and referenced column 'entity_id' in foreign key constraint 'SAMEDAYCOURIER_SHIPPING_AWB_ORDER_ID_SALES_ORDER_ENTITY_ID' are incompatible., query was: ALTER TABLE `samedaycourier_shipping_awb` MODIFY COLUMN `id` int  NOT NULL  AUTO_INCREMENT COMMENT "AWB Local ID", MODIFY COLUMN `order_id` int  NOT NULL   COMMENT "Magento order ID", MODIFY COLUMN `awb_number` varchar(255) NOT NULL  COMMENT "AWB Number", MODIFY COLUMN `parcels` text NOT NULL COMMENT "AWB Parcels", MODIFY COLUMN `awb_cost` decimal(10, 2)  NOT NULL  COMMENT "AWB Cost", COMMENT='Samedaycourier AWB list'
```