### PR TITLE
Expand tracking info

### DIFF
--- a/Helper/ApiHelper.php
+++ b/Helper/ApiHelper.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use Sameday\Exceptions\SamedayBadRequestException;
 use Sameday\Exceptions\SamedaySDKException;
 use Sameday\Objects\Types\AwbPdfType;
+use Sameday\Requests\SamedayGetAwbStatusHistoryRequest;
 use Sameday\Requests\SamedayRequestInterface;
 use Sameday\Responses\SamedayResponseInterface;
 use Sameday\Sameday;
@@ -308,5 +309,19 @@ class ApiHelper extends AbstractHelper
     public function getHostCountry(): string
     {
         return $this->generalHelper->getHostCountry();
+    }
+    public function getAwbHistory($number)
+    {
+        $sameday = $this->initClient();
+        $request = new SamedayGetAwbStatusHistoryRequest($number);
+
+        try {
+            $rawResponse = $sameday->sendRequest($request->buildRequest());
+            $response = new \Sameday\Responses\SamedayGetAwbStatusHistoryResponse($request, $rawResponse);
+
+            return $response;
+        } catch (Exception $e) {
+            return false;
+        }
     }
 }

--- a/Model/TrackingInfo.php
+++ b/Model/TrackingInfo.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SamedayCourier\Shipping\Model;
+
+use Sameday\Responses\SamedayGetAwbStatusHistoryResponse;
+
+class TrackingInfo
+{
+
+    /**
+     * @var string
+     */
+    public $carrierTitle;
+    /**
+     * @var string
+     */
+    public $trackingNumber;
+    /**
+     * @var string
+     */
+    public $trackingUrl;
+    /**
+     * @var string
+     */
+    public $trackSummary;
+
+    public function setCarrierTitle($title): TrackingInfo
+    {
+        $this->carrierTitle = $title;
+        return $this;
+
+    }
+    public function getCarrierTitle(): string
+    {
+        return $this->carrierTitle;
+    }
+    public function setTracking($trackingNumber): TrackingInfo
+    {
+        $this->trackingNumber = $trackingNumber;
+        return $this;
+    }
+    public function getTracking(): string
+    {
+        return $this->trackingNumber;
+
+    }
+    public function setUrl($trackingUrl): TrackingInfo
+    {
+        $this->trackingUrl = $trackingUrl;
+        return $this;
+    }
+    public function getUrl(): string
+    {
+        return $this->trackingUrl;
+
+    }
+    public function setTrackSummary(SamedayGetAwbStatusHistoryResponse $awbHistory): TrackingInfo
+    {
+        $implodedHistory = implode(' | ', array_map(
+            static function ($history) {
+                return $history->date->format('Y-m-d H:i:s') . ": " . $history->label;
+            },
+            $awbHistory->history
+        ));
+        $this->trackSummary = $awbHistory->expeditionStatus->label .PHP_EOL . $implodedHistory;
+        return $this;
+    }
+
+    public function getTrackSummary(): string
+    {
+        return $this->trackSummary;
+    }
+
+}

--- a/Model/TrackingInfo.php
+++ b/Model/TrackingInfo.php
@@ -24,6 +24,8 @@ class TrackingInfo
      */
     public $trackSummary;
 
+    private $awbHistory;
+
     public function setCarrierTitle($title): TrackingInfo
     {
         $this->carrierTitle = $title;
@@ -56,19 +58,32 @@ class TrackingInfo
     }
     public function setTrackSummary(SamedayGetAwbStatusHistoryResponse $awbHistory): TrackingInfo
     {
-        $implodedHistory = implode(' | ', array_map(
-            static function ($history) {
-                return $history->date->format('Y-m-d H:i:s') . ": " . $history->label;
-            },
-            $awbHistory->history
-        ));
-        $this->trackSummary = $awbHistory->expeditionStatus->label .PHP_EOL . $implodedHistory;
+        $this->awbHistory = $awbHistory;
+        $this->trackSummary = $awbHistory->getExpeditionStatus()->getState();
         return $this;
     }
 
-    public function getTrackSummary(): string
+    public function getTrackSummary()
     {
-        return $this->trackSummary;
+        return null; // intentionally null so that magento will show tracking link
+    }
+    public function getErrorMessage()
+    {
+     return null; //intentionally null
+    }
+    public function getProgressdetail()
+    {
+        return array_map(
+            static function ($history) {
+               return  [
+                    'deliverydate'=> $history->getDate()->format('Y-m-d'),
+                    'deliverytime'=> $history->getDate()->format('H:i:s'),
+                    'deliverylocation'=> ($history->getTransitLocation()!=="") ? $history->getTransitLocation() :"N/A",
+                    'activity'=> $history->getState(),
+                ];
+            },
+            $this->awbHistory->getHistory()
+        );
     }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sameday/magento2-plugin",
+  "name": "sameday/magento-2-plugin",
   "description": "Magento 2 plugin for Sameday Courier shipping",
   "require": {
     "sameday-courier/php-sdk": "^v2.1.7",
@@ -10,7 +10,7 @@
         "roave/security-advisories": "dev-latest"
     },
   "type": "magento2-module",
-  "version": "1.8.7-feature-tracking",
+  "version": "1.8.8",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "roave/security-advisories": "dev-latest"
     },
   "type": "magento2-module",
-  "version": "1.8.7",
+  "version": "1.8.7-feature-tracking",
   "autoload": {
     "files": [ "registration.php" ],
     "psr-4": {


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to improve the Sameday Courier Magento 2 plugin. The most notable changes include adding tracking information functionality, creating a new `TrackingInfo` model, and updating the plugin's version and metadata in `composer.json`.

### Tracking functionality improvements:
* Added a new method `getAwbHistory` in `ApiHelper.php` to fetch AWB status history from the Sameday API.
* Updated the `getTrackingInfo` method in `Shipping.php` to utilize the new `TrackingInfo` model for enriched tracking details, including carrier title, tracking number, URL, and status history.
* Introduced a new `TrackingInfo` model to encapsulate tracking details and provide methods for setting and retrieving carrier title, tracking number, URL, and progress details.
